### PR TITLE
Bugfix/6789 no keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: ruby
 rvm:
   - 2.1.5
-  - 1.9.3
 cache: bundler
 notifications:
   email: false
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem update --system 2.2.2
+  - gem install bundler --version 1.7.4
   - gem --version
   - bundle --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.1.5
+  - 1.9.3
+cache: bundler
+notifications:
+  email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ rvm:
 cache: bundler
 notifications:
   email: false
-
+before_install:
+  - gem update --system 2.4.5
+  - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ cache: bundler
 notifications:
   email: false
 before_install:
-  - gem update --system 2.4.5
+  - gem update --system
+  - gem install bundler
   - gem --version
+  - bundle --version

--- a/lib/nickserver.rb
+++ b/lib/nickserver.rb
@@ -5,9 +5,10 @@ require "nickserver/email_address"
 
 require "nickserver/couch/fetch_key"
 
-require "nickserver/hkp/key_info"
-require "nickserver/hkp/fetch_key_info"
 require "nickserver/hkp/fetch_key"
+require "nickserver/hkp/fetch_key_info"
+require "nickserver/hkp/parse_key_info"
+require "nickserver/hkp/key_info"
 
 require "nickserver/server"
 require "nickserver/daemon"

--- a/lib/nickserver/config.rb
+++ b/lib/nickserver/config.rb
@@ -42,12 +42,12 @@ module Nickserver
       if @hkp_ca_file
         # look for the hkp_ca_file either by absolute path or relative to nickserver gem root
         [@hkp_ca_file, File.expand_path(@hkp_ca_file, "#{__FILE__}/../../../")].each do |file|
-          if File.exists?(file)
+          if File.exist?(file)
             @hkp_ca_file = file
             break
           end
         end
-        unless File.exists?(@hkp_ca_file)
+        unless File.exist?(@hkp_ca_file)
           STDERR.puts "ERROR in configuration: cannot find hkp_ca_file `#{@hkp_ca_file}`"
           exit(1)
         end

--- a/lib/nickserver/hkp/fetch_key_info.rb
+++ b/lib/nickserver/hkp/fetch_key_info.rb
@@ -8,23 +8,16 @@ module Nickserver; module HKP
   class FetchKeyInfo
     include EM::Deferrable
 
-    # for this regexp to work, the source text must end in a trailing "\n",
-    # which the output of sks does.
-    MATCH_PUB_KEY = /(^pub:.+?\n(^uid:.+?\n)+)/m
-
     def search(uid)
       # in practice, exact=on seems to have no effect
       params = {:op => 'vindex', :search => uid, :exact => 'on', :options => 'mr', :fingerprint => 'on'}
       EventMachine::HttpRequest.new(Config.hkp_url).get(:query => params).callback {|http|
-        if http.response_header.status != 200
-          self.fail http.response_header.status, "Could net fetch keyinfo."
+        parser = ParseKeyInfo.new http.response_header, http.response
+        keys = parser.keys(uid)
+        if keys.any?
+          self.succeed keys
         else
-          keys, errors = parse(uid, http.response)
-          if keys.empty?
-            self.fail 500, errors.join("\n")
-          else
-            self.succeed keys
-          end
+          self.fail parser.status(uid), parser.msg(uid)
         end
       }.errback {|http|
         self.fail 500, http.error
@@ -32,43 +25,6 @@ module Nickserver; module HKP
       self
     end
 
-    #
-    # input:
-    #  uid           -- uid to search for
-    #  vindex_result -- raw output from a vindex hkp query (machine readable)
-    #
-    # returns:
-    #   an array of:
-    #   [0] -- array of eligible keys (as HKPKeyInfo objects) matching uid.
-    #   [1] -- array of error messages
-    #
-    # keys are eliminated from eligibility for a number of reasons, including expiration,
-    # revocation, uid match, key length, and so on...
-    #
-    def parse(uid, vindex_result)
-      keys = []
-      errors = []
-      now = Time.now
-      vindex_result.scan(MATCH_PUB_KEY).each do |match|
-        key_info = KeyInfo.new(match[0])
-        if key_info.uids.include?(uid)
-          if key_info.keylen < 2048
-            errors << "Ignoring key #{key_info.keyid} for #{uid}: key length is too short."
-          elsif key_info.expired?
-            errors << "Ignoring key #{key_info.keyid} for #{uid}: key expired."
-          elsif key_info.revoked?
-            errors << "Ignoring key #{key_info.keyid} for #{uid}: key revoked."
-          elsif key_info.disabled?
-            errors << "Ignoring key #{key_info.keyid} for #{uid}: key disabled."
-          elsif key_info.expirationdate && key_info.expirationdate < now
-            errors << "Ignoring key #{key_info.keyid} for #{uid}: key expired"
-          else
-            keys << key_info
-          end
-        end
-      end
-      [keys, errors]
-    end
   end
 
 end; end

--- a/lib/nickserver/server.rb
+++ b/lib/nickserver/server.rb
@@ -43,6 +43,8 @@ module Nickserver
         send_key(uid)
       end
     rescue RuntimeError => exc
+      puts "Error: #{exc}"
+      puts exc.backtrace
       send_error(exc.to_s)
     end
 

--- a/nickserver.gemspec
+++ b/nickserver.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'minitest', '~> 5.2'
   gem.add_development_dependency 'webmock', '~> 1.17'
 
-  gem.add_dependency 'eventmachine', '~> 1.0'
+  gem.add_dependency 'eventmachine', '~> 1.0.9'
   gem.add_dependency 'em-http-request', '~> 1.1'
   gem.add_dependency 'eventmachine_httpserver', '~> 0.2'
 end

--- a/test/unit/hkp_test.rb
+++ b/test/unit/hkp_test.rb
@@ -34,6 +34,14 @@ class HkpTest < Minitest::Test
     end
   end
 
+  def test_no_matching_key_found
+    uid = 'leaping_lemur@leap.se'
+    stub_sks_vindex_reponse(uid, :status => 200)
+    test_em_errback "Nickserver::HKP::FetchKeyInfo.new.search '#{uid}'" do |error|
+      assert_equal 404, error
+    end
+  end
+
   def test_fetch_key
     uid    = 'cloudadmin@leap.se'
     key_id = 'E818C478D3141282F7590D29D041EB11B1647490'


### PR DESCRIPTION
I also separated the parsing of the hkp response from
FetchKeyInfo.

This way FetchKeyInfo has the EM specific code that has
side effects and the logic is in a class without side effects
and (almost) without state.

The only state we keep is the memoizing `@all_key_infos` - a KeyInfo array that contains
all the information the server returns. This way we avoid parsing the response multiple times.
